### PR TITLE
멀티 모드 수정 및 구현

### DIFF
--- a/src/friends/friends.controller.ts
+++ b/src/friends/friends.controller.ts
@@ -50,11 +50,32 @@ export class FriendsController {
     },
   })
   @ApiResponse({
-    description: '친구방 만들기 성공',
+    description: '로그인 유저: 친구방 만들기 성공',
     status: 200,
     schema: {
       example: {
-        room: 'new room = { roomid(uuid v4), host(SnsId), headCount(0), status(FRIENDS) }',
+        room: [{
+          id: '1', 
+          roomid: 'a199ead7-4dfc-429a-a62c-84b6039854ac', 
+          host: 'user@example.com', 
+          headCount: '0', 
+          status: 'FRIENDS', 
+        }],
+      },
+    },
+  })
+  @ApiResponse({
+    description: '비로그인 유저: 친구방 만들기 성공 (테스트용)',
+    status: 200,
+    schema: {
+      example: {
+        room: [{
+          id: 'id', 
+          roomid: 'a199ead7-4dfc-429a-a62c-84b6039854ac', 
+          host: 'member1', 
+          headCount: '0', 
+          status: 'FRIENDS', 
+        }],
       },
     },
   })
@@ -92,9 +113,44 @@ export class FriendsController {
     status: 200,
     schema: {
       example: {
-        room: 'new room = { roomid, host, headCount(++), status(FRIENDS) }',
-        memberList: '방에 입장 member들을 Array로 반환',
-        userList: '방에 입장 user들을 Array로 반환',
+        userList: [[
+          {
+            id: '1',
+            SnsId: 'user@example.com',
+            Nick: 'exampleUser',
+            Provider: 'examplePlatform',
+            point: 0,
+            all: 'tjwmqoalx-example-code1',
+            createAt: '2022-05-23T07:09:54.678Z',
+            deleteAt: null,
+            updateAt: '2022-05-23T07:09:54.678Z'
+          },
+        ]],
+        memberList: [[
+          {
+            id: '1',
+            Nick: 'exampleMember',
+            all: 'tjwmqoalx-example-code2',
+            createAt: '2022-05-23T07:09:54.678Z',
+            deleteAt: null,
+            updateAt: '2022-05-23T07:09:54.678Z'
+          },
+          {
+            id: '5',
+            Nick: 'exampleMember',
+            all: 'tjwmqoalx-example-code3',
+            createAt: '2022-05-23T07:10:54.678Z',
+            deleteAt: null,
+            updateAt: '2022-05-23T07:10:54.678Z'
+          }
+        ]],
+        room: [{ 
+          id: '1',
+          roomid: 'a199ead7-4dfc-429a-a62c-84b6039854ac', 
+          host: 'host', 
+          headCount: '3', 
+          status: 'FRIENDS', 
+        }],
       },
     },
   })
@@ -113,22 +169,44 @@ export class FriendsController {
     name: 'roomid',
     description: '방 코드',
   })
-  @ApiQuery({
-    name: 'perPage',
-    description: '몇 개의 메세지를 가져올 것인지',
-    example: 10,
-  })
-  @ApiQuery({
-    name: 'page',
-    description: '얼마나 건너뛸 것인지',
-    example: 1,
-  })
   @ApiResponse({
-    description: '친구방 채팅 가져오기 성공',
+    description: '친구방 채팅 가져오기 성공 (최근 10개의 채팅만 가져옴)',
     status: 200,
     schema: {
       example: {
-        roomChats: '생성 역순으로 채팅 여러 개를 가져옴',
+        roomChats: [[
+          {
+            id: 1,
+            content: 'hi',
+            createdAt: '2022-05-23T07:27:16.467Z',
+            user: null,
+            member: [{
+              id: '1',
+              Nick: 'exampleMember',
+              all: 'tjwmqoalx-example-code2',
+              createAt: '2022-05-23T07:09:54.678Z',
+              deleteAt: null,
+              updateAt: '2022-05-23T07:09:54.678Z'
+            },]
+          },
+          {
+            id: 2,
+            content: 'hello',
+            createdAt: '2022-05-23T07:27:20.467Z',
+            user: [{
+              id: '1',
+              SnsId: 'user@example.com',
+              Nick: 'exampleUser',
+              Provider: 'examplePlatform',
+              point: 0,
+              all: 'tjwmqoalx-example-code1',
+              createAt: '2022-05-23T07:09:54.678Z',
+              deleteAt: null,
+              updateAt: '2022-05-23T07:09:54.678Z'
+            },],
+            member: null,
+          },
+        ]],
       },
     },
   })
@@ -136,10 +214,8 @@ export class FriendsController {
   @Get(':roomid/chats')
   async getFriendsRoomChats(
     @Param('roomid') roomid: string,
-    @Query('perPage', ParseIntPipe) perPage: number,
-    @Query('page', ParseIntPipe) page: number,
   ) {
-    return await this.friendsService.getFriendsRoomChats(roomid, perPage, page);
+    return await this.friendsService.getFriendsRoomChats(roomid);
   }
 
   @ApiHeader({
@@ -167,11 +243,11 @@ export class FriendsController {
     },
   })
   @ApiResponse({
-    description: '친구방 채팅 생성 성공',
+    description: '친구방 채팅 생성 성공 (socket으로 chatWithUser 전송)',
     status: 200,
     schema: {
       example: {
-        response: '/room-friends-roomid room으로 메세지 전송',
+        result: 'success',
       },
     },
   })

--- a/src/friends/friends.service.ts
+++ b/src/friends/friends.service.ts
@@ -65,6 +65,15 @@ export class FriendsService {
       }
       // 테스트용: 비로그인 시에도 가능하게끔
       else {
+        // 중복 닉네임 예외처리
+        const duplicate_check = await this.memberRepository.findOne({
+          where: { Nick: nick },
+        });
+
+        if (duplicate_check) {
+          throw new HttpException('Duplicated Nickname', HttpStatus.BAD_REQUEST);
+        }
+
         const roomid: string = v4();
 
         const room = new Room();

--- a/src/friends/friends.service.ts
+++ b/src/friends/friends.service.ts
@@ -192,7 +192,7 @@ export class FriendsService {
     }
   }
 
-  async getFriendsRoomChats(roomid: string, perPage: number, page: number) {
+  async getFriendsRoomChats(roomid: string) {
     return this.friendsRoomChatRepository
       .createQueryBuilder('roomChats')
       .innerJoin('roomChats.room', 'room', 'room.roomid = :roomid', {
@@ -201,8 +201,7 @@ export class FriendsService {
       .leftJoinAndSelect('roomChats.user', 'user')
       .leftJoinAndSelect('roomChats.member', 'member')
       .orderBy('roomChats.createdAt', 'DESC')
-      .take(perPage)
-      .skip(perPage * (page - 1))
+      .take(10)
       .getMany();
   }
 
@@ -276,6 +275,7 @@ export class FriendsService {
       console.log(
         `/room-${chatWithUser.room.status}-${chatWithUser.room.roomid}`,
       );
+      return { result: 'success' };
     }
   }
 }

--- a/src/friends/friends.service.ts
+++ b/src/friends/friends.service.ts
@@ -83,9 +83,10 @@ export class FriendsService {
         room.status = 'FRIENDS';
         await this.friendsRoomRepository.save(room);
 
-        const member = new Member();
-        member.Nick = nick;
-        await this.memberRepository.save(member);
+        // 바로 입장을 진행하기 때문에 member 생성은 방 입장 시 진행
+        // const member = new Member();
+        // member.Nick = nick;
+        // await this.memberRepository.save(member);
         return room;
       }
     }

--- a/src/random/random.controller.ts
+++ b/src/random/random.controller.ts
@@ -1,4 +1,81 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Get, Post, Headers } from '@nestjs/common';
+import { ApiBody, ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { RandomService } from './random.service';
 
-@Controller('random')
-export class RandomController {}
+@ApiTags('Multi - Random')
+@Controller('mode/random')
+export class RandomController {
+    constructor(private randomService: RandomService){}
+
+    // @Get()
+    // getRandomRoomList(){
+
+    // }
+
+    @ApiHeader({
+        name: 'Authorization',
+        description: 'eyJhGcioJ와 같은 accessToken',
+    })
+    @ApiBody({
+        description: '비로그인 유저는 닉네임, 로그인 유저는 null',
+        schema: {
+            example: { nick: 'example' },
+        },
+    })
+    @ApiResponse({
+        description: '로그인 유저: 랜덤방 만들기 성공',
+        status: 200,
+        schema: {
+            example: {
+                result: 'create success',
+                room: [{
+                    id: 'id', 
+                    roomid: 'b7817821-dc63-4f09-97cc-32d466701077', 
+                    host: 'user@example.com', 
+                    headCount: '0', 
+                    status: 'RANDOM', 
+                }],
+            },
+        },
+    })
+    @ApiResponse({
+        description: '비로그인 유저: 랜덤방 만들기 성공',
+        status: 200,
+        schema: {
+            example: {
+                result: 'create success',
+                room: [{
+                    id: 'id', 
+                    roomid: 'b7817821-dc63-4f09-97cc-32d466701077', 
+                    host: 'member1', 
+                    headCount: '0', 
+                    status: 'RANDOM', 
+                }],
+            },
+        },
+    })
+    @ApiResponse({
+        description: '매칭 성공',
+        status: 200,
+        schema: {
+            example: {
+                result: 'matching success',
+                room: [{
+                    id: 'id', 
+                    roomid: 'b7817821-dc63-4f09-97cc-32d466701077', 
+                    host: 'member1', 
+                    headCount: '5', 
+                    status: 'RANDOM', 
+                }],
+            },
+        },
+    })
+    @ApiOperation({ summary: '랜덤매칭' })
+    @Post('')
+    async createOrMatch(
+        @Headers('Authorization') token: any,
+        @Body('nick') nick: string,
+    ){
+        return this.randomService.createOrMatch(token, nick);
+    }
+}

--- a/src/random/random.controller.ts
+++ b/src/random/random.controller.ts
@@ -1,5 +1,12 @@
-import { Body, Controller, Get, Post, Headers } from '@nestjs/common';
-import { ApiBody, ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { 
+    Body, 
+    Controller, 
+    Get, 
+    Post, 
+    Headers, 
+    Param 
+} from '@nestjs/common';
+import { ApiBody, ApiHeader, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { RandomService } from './random.service';
 
 @ApiTags('Multi - Random')
@@ -12,42 +19,16 @@ export class RandomController {
 
     // }
 
-    @ApiHeader({
-        name: 'Authorization',
-        description: 'eyJhGcioJ와 같은 accessToken',
-    })
-    @ApiBody({
-        description: '비로그인 유저는 닉네임, 로그인 유저는 null',
-        schema: {
-            example: { nick: 'example' },
-        },
-    })
-    @ApiResponse({
-        description: '로그인 유저: 랜덤방 만들기 성공',
-        status: 200,
-        schema: {
-            example: {
-                result: 'create success',
-                room: [{
-                    id: 'id', 
-                    roomid: 'b7817821-dc63-4f09-97cc-32d466701077', 
-                    host: 'user@example.com', 
-                    headCount: '0', 
-                    status: 'RANDOM', 
-                }],
-            },
-        },
-    })
     @ApiResponse({
         description: '비로그인 유저: 랜덤방 만들기 성공',
-        status: 200,
+        status: 201,
         schema: {
             example: {
                 result: 'create success',
                 room: [{
                     id: 'id', 
                     roomid: 'b7817821-dc63-4f09-97cc-32d466701077', 
-                    host: 'member1', 
+                    host: 'RANDOM', 
                     headCount: '0', 
                     status: 'RANDOM', 
                 }],
@@ -72,10 +53,85 @@ export class RandomController {
     })
     @ApiOperation({ summary: '랜덤매칭' })
     @Post('')
-    async createOrMatch(
+    async createOrMatchRoom(){
+        return this.randomService.createOrMatch();
+    }
+
+    @ApiParam({
+        name: 'roomid',
+        description: '입장하려는 방 코드',
+    })
+    @ApiHeader({
+        name: 'Authorization',
+        description: 'eyJhGcioJ와 같은 accessToken',
+    })
+    @ApiBody({
+        description: '비로그인 유저는 닉네임, 로그인 유저는 null',
+        schema: {
+            example: { nick: 'example' },
+        },
+    })
+    @ApiResponse({
+        description: 'not exist room',
+        status: 404,
+        schema: {
+            example: { success: false, code: 404, data: 'unknown error' },
+        },
+    })
+    @ApiResponse({
+        description: '로그인 유저 - 랜덤방 입장 성공',
+        status: 200,
+        schema: {
+            example: {
+                userList: [[
+                    {
+                        id: '1',
+                        SnsId: 'user@example.com',
+                        Nick: 'exampleUser',
+                        Provider: 'examplePlatform',
+                        point: 0,
+                        all: 'tjwmqoalx-example-code1',
+                        createAt: '2022-05-23T07:09:54.678Z',
+                        deleteAt: null,
+                        updateAt: '2022-05-23T07:09:54.678Z'
+                    },
+                ]],
+                memberList: [[
+                    {
+                        id: '1',
+                        Nick: 'exampleMember',
+                        all: 'tjwmqoalx-example-code2',
+                        createAt: '2022-05-23T07:09:54.678Z',
+                        deleteAt: null,
+                        updateAt: '2022-05-23T07:09:54.678Z'
+                    },
+                    {
+                        id: '5',
+                        Nick: 'exampleMember',
+                        all: 'tjwmqoalx-example-code3',
+                        createAt: '2022-05-23T07:10:54.678Z',
+                        deleteAt: null,
+                        updateAt: '2022-05-23T07:10:54.678Z'
+                    }
+                ]], 
+                room: [{ 
+                    id: '1',
+                    roomid: 'a199ead7-4dfc-429a-a62c-84b6039854ac', 
+                    host: 'host', 
+                    headCount: '3', 
+                    status: 'FRIENDS', 
+                }],
+            },
+        },
+    })
+    @ApiOperation({ summary: '랜덤방 입장하기' })
+    @Post(':roomid')
+    async getRandomRoom(
+        @Param('roomid') roomid: string,
         @Headers('Authorization') token: any,
         @Body('nick') nick: string,
+        @Body('imgCode') imgCode: string,
     ){
-        return this.randomService.createOrMatch(token, nick);
+        return this.randomService.enterRoom(roomid, token, nick, imgCode);
     }
 }

--- a/src/random/random.module.ts
+++ b/src/random/random.module.ts
@@ -1,8 +1,22 @@
 import { Module } from '@nestjs/common';
 import { RandomService } from './random.service';
 import { RandomController } from './random.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { RoomChat } from 'src/entities/RoomChat';
+import { Room } from 'src/entities/Room';
+import { User } from 'src/entities/User';
+import { ConfigService } from '@nestjs/config';
+import { MultiModule } from 'src/multi/multi.module';
+import { OauthModule } from 'src/oauth/oauth.module';
+import { Member } from 'src/entities/Member';
 
 @Module({
+  imports: [
+    TypeOrmModule.forFeature([Room, RoomChat, User, Member]),
+    MultiModule,
+    OauthModule,
+    ConfigService
+  ],
   providers: [RandomService],
   controllers: [RandomController]
 })

--- a/src/random/random.service.ts
+++ b/src/random/random.service.ts
@@ -30,69 +30,24 @@ export class RandomService {
         private readonly config: ConfigService,
     ){}
 
-    async createOrMatch(token: any, nick: string){
+    async createOrMatch(){
         // 들어갈 방이 있을 때 들어갈 방 리턴
         const matchRoom = await this.findRoom();
-        console.log(matchRoom)
+
         if(matchRoom != null){
             return { result: 'matching success', matchRoom };
         }
 
-        let userData: jwtParsed;
-        let flag: boolean = true;
-
-        try {
-            userData = jwt.verify(token, this.config.get('secret'));
-        } catch (error) {
-            flag = false;
-        } finally {
-            if (flag) {
-                const existUser = await this.userRepository.findOne({
-                    where: {
-                        SnsId: userData.id,
-                        Provider: userData.provider,
-                    },
-                });
+        const roomid: string = v4();
         
-                // 로그인 한 경우 가능
-                if (existUser) {
-                    const roomid: string = v4();
+        const room = new Room();
+        room.roomid = roomid;
+        room.host = 'RANDOM';
+        room.headCount = 0;
+        room.status = 'RANDOM';
+        await this.randomRoomRepository.save(room);
         
-                    const room = new Room();
-                    room.roomid = roomid;
-                    room.host = existUser.SnsId;
-                    room.headCount = 0;
-                    room.status = 'RANDOM';
-                    await this.randomRoomRepository.save(room);
-                    return { result: 'create success', room };
-                }
-            }
-
-            else {
-                // 중복 닉네임 예외처리
-                const duplicate_check = await this.memberRepository.findOne({
-                    where: { Nick: nick },
-                });
-  
-                if (duplicate_check) {
-                    throw new HttpException('Duplicated Nickname', HttpStatus.BAD_REQUEST);
-                }
-
-                const roomid: string = v4();
-        
-                const room = new Room();
-                room.roomid = roomid;
-                room.host = nick;
-                room.headCount = 0;
-                room.status = 'RANDOM';
-                await this.randomRoomRepository.save(room);
-        
-                const member = new Member();
-                member.Nick = nick;
-                await this.memberRepository.save(member);
-                return { result: 'create success', room };
-            }
-        }
+        return { result: 'create success', room };
     }
 
     async findRoom(){
@@ -108,6 +63,83 @@ export class RandomService {
         } else{
             return null;
         }
+    }
 
+    async enterRoom(
+        roomid: string, 
+        token: any, 
+        nick: string, 
+        imgCode: string
+    ){
+        let userData: jwtParsed;
+        let flag: boolean = true;
+
+        try {
+            userData = jwt.verify(token, this.config.get('secret'));
+        } catch (error) {
+            flag = false;
+        } finally {
+            const room = await this.randomRoomRepository.findOne({
+                where: { roomid: roomid },
+            });
+
+            // 없는 방이거나 6명 이상인 경우
+            if (!room || room.headCount >= 6) {
+                throw new HttpException('Not Exist Room', HttpStatus.NOT_FOUND);
+            }
+
+            if (flag) {
+                const existUser = await this.userRepository.findOne({
+                    where: {
+                        SnsId: userData.id,
+                        Provider: userData.provider,
+                    },
+                });
+                if (existUser) {
+                    existUser.room = room;
+                    existUser.all = imgCode;
+                    await this.userRepository.save(existUser);
+                }
+                else{
+                    flag = false
+                }
+            }
+
+            // 로그인을 하지 않은 유저
+            if(!flag){
+                const duplicate_check = await this.memberRepository.findOne({
+                    where: { Nick: nick },
+                });
+
+                if (duplicate_check) {
+                    throw new HttpException('Duplicated Nickname', HttpStatus.BAD_REQUEST);
+                }
+
+                const member = new Member();
+                member.Nick = nick;
+                member.room = room;
+                member.all = imgCode;
+                await this.memberRepository.save(member);
+            }
+
+            const memberList: Array<Member> = await this.memberRepository
+                .createQueryBuilder('members')
+                .innerJoin('members.room', 'room', 'room.roomid = :roomid', {
+                    roomid,
+                })
+                .getMany();
+
+            room.headCount += 1;
+            await this.randomRoomRepository.save(room);
+
+            const userList: Array<Member> = await this.userRepository
+                .createQueryBuilder('users')
+                .innerJoin('users.room', 'room', 'room.roomid = :roomid', {
+                    roomid,
+                })
+                .getMany();
+
+            return { userList, memberList, room };
+        }
     }
 }

--- a/src/random/random.service.ts
+++ b/src/random/random.service.ts
@@ -1,4 +1,113 @@
-import { Injectable } from '@nestjs/common';
+import { 
+    HttpException, 
+    HttpStatus, 
+    Injectable 
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Member } from 'src/entities/Member';
+import { Room } from 'src/entities/Room';
+import { RoomChat } from 'src/entities/RoomChat';
+import { User } from 'src/entities/User';
+import { MultiGateway } from 'src/multi/multi.gateway';
+import { jwtParsed } from 'src/user/dto/userdata.dto';
+import { Not, Repository } from 'typeorm';
+import * as jwt from 'jsonwebtoken';
+import { v4 } from 'uuid';
 
 @Injectable()
-export class RandomService {}
+export class RandomService {
+    constructor(
+        @InjectRepository(Room)
+        private randomRoomRepository: Repository<Room>,
+        @InjectRepository(RoomChat)
+        private randomRoomChatRepository: Repository<RoomChat>,
+        @InjectRepository(User)
+        private userRepository: Repository<User>,
+        @InjectRepository(Member)
+        private memberRepository: Repository<Member>,
+        private readonly multiGatway: MultiGateway,
+        private readonly config: ConfigService,
+    ){}
+
+    async createOrMatch(token: any, nick: string){
+        // 들어갈 방이 있을 때 들어갈 방 리턴
+        const matchRoom = await this.findRoom();
+        console.log(matchRoom)
+        if(matchRoom != null){
+            return { result: 'matching success', matchRoom };
+        }
+
+        let userData: jwtParsed;
+        let flag: boolean = true;
+
+        try {
+            userData = jwt.verify(token, this.config.get('secret'));
+        } catch (error) {
+            flag = false;
+        } finally {
+            if (flag) {
+                const existUser = await this.userRepository.findOne({
+                    where: {
+                        SnsId: userData.id,
+                        Provider: userData.provider,
+                    },
+                });
+        
+                // 로그인 한 경우 가능
+                if (existUser) {
+                    const roomid: string = v4();
+        
+                    const room = new Room();
+                    room.roomid = roomid;
+                    room.host = existUser.SnsId;
+                    room.headCount = 0;
+                    room.status = 'RANDOM';
+                    await this.randomRoomRepository.save(room);
+                    return { result: 'create success', room };
+                }
+            }
+
+            else {
+                // 중복 닉네임 예외처리
+                const duplicate_check = await this.memberRepository.findOne({
+                    where: { Nick: nick },
+                });
+  
+                if (duplicate_check) {
+                    throw new HttpException('Duplicated Nickname', HttpStatus.BAD_REQUEST);
+                }
+
+                const roomid: string = v4();
+        
+                const room = new Room();
+                room.roomid = roomid;
+                room.host = nick;
+                room.headCount = 0;
+                room.status = 'RANDOM';
+                await this.randomRoomRepository.save(room);
+        
+                const member = new Member();
+                member.Nick = nick;
+                await this.memberRepository.save(member);
+                return { result: 'create success', room };
+            }
+        }
+    }
+
+    async findRoom(){
+        const room = await this.randomRoomRepository.findOne({
+            where: {
+                status: 'RANDOM',
+                headCount: Not(6),
+            },
+        });
+
+        if(room){
+            return room;
+        } else{
+            return null;
+        }
+
+    }
+}


### PR DESCRIPTION
- 친구모드
   - api 명세 수정
   - 채팅 가져오기 api에서 perPage, page 삭제 및 고정값으로 변경
   - 친구 방 만들기 비로그인 유저 닉네임 중복체크
   - 방 만들기에서 비로그인 유저(member) 생성 삭제 (host도 입장 시 생성 / 테스트용이라 추후 비로그인 유저의 방만들기 권한 삭제 예정)
- 랜덤모드
   - 랜덤 매칭 구현 (방이 있으면 입장, 방이 없으면 생성 후 매칭) (60초 매칭은 구현 X)
   - 방 입장 구현 (친구모드와 유사)
   - 매칭 및 입장 api 명세  